### PR TITLE
Add preference to prevent load timeout

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -19,6 +19,7 @@
     <preference name="SplashShowOnlyFirstTime" value="false" />
     <preference name="SplashScreen" value="screen" />
     <preference name="SplashScreenDelay" value="3000" />
+    <preference name="LoadUrlTimeoutValue" value="99999999" />
     <platform name="android">
         <allow-intent href="market:*" />
         <icon density="ldpi" src="resources/android/icon/drawable-ldpi-icon.png" />


### PR DESCRIPTION
Resolve cordova initial load timeout that appears on old devices.

Closes #12 